### PR TITLE
Fix for issue #1

### DIFF
--- a/src/transform.coffee
+++ b/src/transform.coffee
@@ -10,7 +10,7 @@ module.exports =
       .update '\0', 'utf8'
       .update sourcePath
       .update '\0', 'utf8'
-      .update configString
+      .update if typeof configString is 'string' then configString else JSON.stringify configString
       .update '\0', 'utf8'
       .update readFileSync __filename
       .digest 'hex'


### PR DESCRIPTION
`configString` was passing in as an object, not as a string as expected. No idea what's changed over the past year ... but this fixes that and future-proofs it a bit in case something changes again and it starts passing as a string again.